### PR TITLE
Modified name of saved file for zwspxnyn for parallelization.

### DIFF
--- a/kraskovStoegbauerGrassberger/MIxnyn.m
+++ b/kraskovStoegbauerGrassberger/MIxnyn.m
@@ -73,12 +73,20 @@ end
 
 
 % save data for C-Programm
+
+savestr = ['zwspMIxnyn-' num2str(dec2hex(round(rand(1)*100000))) '.txt'];
+while isfile(savestr)
+    savestr = ['zwspMIxnyn-' num2str(dec2hex(round(rand(1)*100000))) '.txt'];
+end
+
 zwsp=[x;y]';
-save zwspMIxnyn.txt zwsp -ASCII
+save(savestr, 'zwsp', '-ASCII');
 
 
 % execute C Programm
-[a unout]=unix(['MIxnyn zwspMIxnyn.txt ',num2str(Ndx),' ',num2str(Ndy),' ',num2str(N),' ',num2str(kneig)]);
+[a unout]=unix(['MIxnyn ',savestr,' ',num2str(Ndx),' ',num2str(Ndy),' ',num2str(N),' ',num2str(kneig)]);
 miout=str2num(unout);
+
+delete(savestr);
 
 


### PR DESCRIPTION
Modification uses a randomly generated unique file name to save the txt file for MIxnyn so that parallel instances of script work correctly.